### PR TITLE
change path to env for mac os

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 import fs from 'fs'
 import program from 'commander'


### PR DESCRIPTION
On Mac OS 10.14.6 (Mojave), `env` is not stored in `/bin/`. From my understanding, this should work without an issue on linux distros due to `env` being in both `/bin` and `/usr/bin`. Have not personally tested it in a distro