### PR TITLE
Ensure regex matches the exact tag.

### DIFF
--- a/src/mjml2json.js
+++ b/src/mjml2json.js
@@ -42,7 +42,7 @@ function cleanNode(node) {
  * Avoid htmlparser to parse ending tags
  */
 function addCDATASection(content) {
-  const regexTag = tag => new RegExp(`<${tag}([^>/]*)>([^]*?)</${tag}>`, 'gmi')
+  const regexTag = tag => new RegExp(`<${tag}((?:[ \n][^>/]*)?)>([^]*?)</${tag}>`, 'gmi')
   const replaceTag = tag => `<${tag}$1><![CDATA[$2]]></${tag}>`
 
   _.forEach(CDATASections, tag => {


### PR DESCRIPTION
Currently, the regex will match the beginning of the tag (e.g. `<mj-image*`), instead of looking for an exact match. This works fine if you're using the default MJML components. However, if you have a custom component, like `mj-image-variable`, it will look for `<mj-image*`, which means it'll match `<mj-image-variable`, causing issues.

Current regex:
https://regex101.com/r/OouqpK/1

Updated regex:
https://regex101.com/r/e4fEY6/1/